### PR TITLE
Add composer require support for Magento 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Webhooks for Magento 2",
     "require": {
         "php": "~5.4.11|~5.5.0|~5.6.0|~7.2.0|~7.3.0",
-        "magento/module-backend": "1.0.0-beta|^100|^101",
+        "magento/module-backend": "1.0.0-beta|^100|^101"
     },
     "type": "magento2-module",
     "version": "0.2.0",

--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,8 @@
     "name": "sweettooth/magento2-module-webhook",
     "description": "Webhooks for Magento 2",
     "require": {
-        "php": "~5.4.11|~5.5.0|~5.6.0",
-        "magento/module-backend": "1.0.0-beta",
-        "magento/module-store": "1.0.0-beta",
-        "magento/framework": "1.0.0-beta",
-        "magento/magento-composer-installer": "*"
+        "php": "~5.4.11|~5.5.0|~5.6.0|~7.2.0|~7.3.0",
+        "magento/module-backend": "1.0.0-beta|^100|^101",
     },
     "type": "magento2-module",
     "version": "0.2.0",


### PR DESCRIPTION
Added php7.3 requirement which M2.3 uses now
Added version requirement to module-backend for M2.3
Removed unnecessary require lines. Only the "magento/module-backend" line is needed. It requires the other modules as needed.

